### PR TITLE
Adjust Readme to improve formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
-#DiceRoll
-##Includes
+# DiceRoll
+
+## Includes
 The Risk boardgame dice roll probability calculator and battle simulation. 
 
-##Description
+## Description
 This application will help you understand the mathematics and statistics behind Risk dice throws. 
 
 You can use it to calculate general probabilities or simulate specific battle situations. 
 
 The simulator will use 10.000 fights (roughly 50.000 dice rolls) to determine the outcome.
 
-##Demo
+## Demo
 http://diceroll.stritar.net/Risk.html
-##Documentation
+
+## Documentation
 http://stritar.net/Post/The-Risk-board-game-dice-roll-probability-calculator-and-battle-simulator.aspx


### PR DESCRIPTION
It looks like `##Text` does not render properly as a heading, so I simply added spacing in order to improve the visual clarity of the README.